### PR TITLE
Allocate only one Label per tag type, and only one default Label.

### DIFF
--- a/src/test/scala/EidosSpec.scala
+++ b/src/test/scala/EidosSpec.scala
@@ -83,9 +83,8 @@ class EidosSpec extends Specification with TypecheckMatchers with ScalaCheck {
   "Tag" should {
     "be case objects" in {
       trait Trait
-
-      // MakeLabel is the reason why "case" is required
-      object Object extends MakeLabel
+      class Class
+      object Object
       type Object = Object.type
 
       case object CaseObject
@@ -96,6 +95,7 @@ class EidosSpec extends Specification with TypecheckMatchers with ScalaCheck {
 
       // format: off
       { typecheck("""Id.of[Trait]("")""") must failWith(errorMessage("Trait")) }
+      { typecheck("""Id.of[Class]("")""") must failWith(errorMessage("Class")) }
       { typecheck("""Id.of[Object]("")""") must failWith(errorMessage("Object")) }
       { typecheck("""Id.of[CaseObject]("")""") must succeed }
       // format: on


### PR DESCRIPTION
I was looking at potential memory optimisations in an application and noticed that currently, a new Label is created for each Id. This can be avoided by:
- Having Label.default always return an existing single default Label value
- Defining the implicit on CustomLabel as a val instead
- Defining the implicit on MakeLabel as a val, ~though this comes at the cost of a self type error when attempting to use a non-case object as a tag.~